### PR TITLE
styling fixes for team and carousel

### DIFF
--- a/src/components/Content.js
+++ b/src/components/Content.js
@@ -8,7 +8,7 @@ const Content = () => {
   const classesCommon = common();
   return (
     <main
-      style={{ flex: 1, height: "100vh" }}
+      style={{ flex: 1, display: "flex" }}
       className={classesCommon.lightGray}
     >
       <Switch>

--- a/src/pages/Team.js
+++ b/src/pages/Team.js
@@ -5,14 +5,13 @@ const Team = () => {
   return (
     <Grid
       container
-      justify="center"
       alignItems="center"
       style={{
         display: "flex",
         flexDirection: "column",
       }}
     >
-      <h2 align="center">Nasi Specjaliści</h2>
+      <h2>Nasi Specjaliści</h2>
       <TeamMemberList />
     </Grid>
   );

--- a/src/styles/carousel.js
+++ b/src/styles/carousel.js
@@ -2,7 +2,6 @@ import { makeStyles } from "@material-ui/core/styles";
 
 const carousel = makeStyles((theme) => ({
   carousel: {
-    height: "100%",
     width: "100%",
   },
   carouselInner: {


### PR DESCRIPTION
removed height 100% from carousel styles, added flex to Content and removed 100vh from there. Removed justify="center" from Grid in Team page component. Now the height is correct.