### PR TITLE
common classes change to fix drawer background color

### DIFF
--- a/src/styles/common.js
+++ b/src/styles/common.js
@@ -5,7 +5,7 @@ const common = makeStyles((theme) => ({
     backgroundColor: "#D8DDE1",
   },
   grayColor: {
-    backgroundColor: theme.palette.grey["A400"],
+    backgroundColor: theme.palette.grey["A400"] + "!important",
     color: theme.palette.common.white,
     fontWeight: theme.typography.fontWeightBold,
   },


### PR DESCRIPTION
Added important to backgroundColor in grayColor class in common styles to fix drawer not diplaying proper bg-color.